### PR TITLE
std::invalid_argument compilation error

### DIFF
--- a/crypto/equihash.h
+++ b/crypto/equihash.h
@@ -14,6 +14,7 @@
 #include "sodium.h"
 
 #include <cstring>
+#include <stdexcept>
 #include <exception>
 #include <functional>
 #include <memory>


### PR DESCRIPTION
behaviour seen with g++ 10.2

```
In file included from ../equihashverify.cc:6:
../equihashverify.cc: In function ‘int verifyEH(const char*, const std::vector<unsigned char>&, const char*, unsigned int, unsigned int)’:
../crypto/equihash.h:224:20: error: ‘invalid_argument’ is not a member of ‘std’
  224 |         throw std::invalid_argument("Unsupported Equihash parameters"); \
      |                    ^~~~~~~~~~~~~~~~
```